### PR TITLE
Backtrace silencers

### DIFF
--- a/lib/hatchet/configuration.rb
+++ b/lib/hatchet/configuration.rb
@@ -48,6 +48,46 @@ module Hatchet
 
     alias_method :backtrace_filters, :backtrace_filter
 
+    # Public: Adds backtrace silencers provided in the form of a Hash.
+    #
+    # Each line of the backtrace starting with a key is replaced by its
+    # corresponding value.
+    #
+    # Example
+    #
+    #   configuration.configure do |config|
+    #     config.backtrace_silencer /foo/
+    #   end
+    #
+    # Will silencer a backtrace line like:
+    #
+    #   /applications/my_app/releases/current/lib/foo.rb:42:in `main'
+    #   /applications/my_app/releases/current/lib/example.rb:42:in `call_thing'
+    #
+    # Into:
+    #
+    #   /applications/my_app/releases/current/lib/example.rb:42:in `call_thing'
+    #
+    # Returns nothing.
+    #
+    def backtrace_silencer(silencers = nil)
+      if silencers
+        @backtrace_silencers = silencers.map do |silencer| 
+          case silencer
+          when Regexp
+            silencer
+          when String
+            /#{silencer}/i
+          else
+            nil
+          end
+        end.compact
+      end
+      @backtrace_silencers
+    end
+
+    alias_method :backtrace_silencers, :backtrace_silencer
+
     # Public: Returns the default formatter given to the appenders that have not
     # had their formatter explicitly set.
     #
@@ -68,6 +108,7 @@ module Hatchet
     #
     def reset!
       @backtrace_filters = {}
+      @backtrace_silencers = []
       @levels = { nil => :info }
       @appenders = []
 

--- a/lib/hatchet/hatchet_logger.rb
+++ b/lib/hatchet/hatchet_logger.rb
@@ -388,7 +388,13 @@ module Hatchet
       @configuration ||= Hatchet.configuration
       @ndc = Hatchet::NestedDiagnosticContext.current
 
-      msg = Message.new(ndc: @ndc.context.clone, message: message, error: error, backtrace_filters: @configuration.backtrace_filters, &block)
+      msg = Message.new({
+        ndc: @ndc.context.clone,
+        message: message,
+        error: error,
+        backtrace_filters: @configuration.backtrace_filters,
+        backtrace_silencers: @configuration.backtrace_silencers
+      }, &block)
 
       @configuration.appenders.each do |appender|
         if appender.enabled?(level, @context)

--- a/lib/hatchet/hatchet_logger.rb
+++ b/lib/hatchet/hatchet_logger.rb
@@ -386,7 +386,7 @@ module Hatchet
       # Ensure configuration and context set - can be lost by marshalling and
       # unmarshalling the logger.
       @configuration ||= Hatchet.configuration
-      @ndc ||= Hatchet::NestedDiagnosticContext.current
+      @ndc = Hatchet::NestedDiagnosticContext.current
 
       msg = Message.new(ndc: @ndc.context.clone, message: message, error: error, backtrace_filters: @configuration.backtrace_filters, &block)
 

--- a/lib/hatchet/message.rb
+++ b/lib/hatchet/message.rb
@@ -18,17 +18,17 @@ module Hatchet
   class Message
 
     class ErrorDecorator < SimpleDelegator
-      def initialize(error, backtrace_filters, backtrace_silencers: [])
+      def initialize(error, backtrace_filters, backtrace_silencers: nil)
         super(error)
         @error = error
-        @backtrace_silencers = backtrace_silencers
+        @backtrace_silencers = backtrace_silencers || []
         @backtrace_filters = backtrace_filters
       end
 
       def backtrace
         @backtrace ||= @error
           .backtrace
-          .reject { |line| @backtrace_silencers.any? { |silencer| line.match?(silences) } }
+          .reject { |line| @backtrace_silencers.any? { |silencer| line.match?(silencer) } }
           .map { |line| __filtered_line(line) }
       end
 
@@ -104,7 +104,7 @@ module Hatchet
         @message = args unless block
       end
 
-      @error = ErrorDecorator.new(@error, args[:backtrace_filters]) if @error && args[:backtrace_filters]
+      @error = ErrorDecorator.new(@error, args[:backtrace_filters], backtrace_silencers: args[:backtrace_silencers]) if @error && args[:backtrace_filters]
       @block = block
     end
 

--- a/lib/hatchet/message.rb
+++ b/lib/hatchet/message.rb
@@ -18,14 +18,18 @@ module Hatchet
   class Message
 
     class ErrorDecorator < SimpleDelegator
-      def initialize(error, backtrace_filters)
+      def initialize(error, backtrace_filters, backtrace_silencers: [])
         super(error)
         @error = error
+        @backtrace_silencers = backtrace_silencers
         @backtrace_filters = backtrace_filters
       end
 
       def backtrace
-        @backtrace ||= @error.backtrace.map { |line| __filtered_line(line) }
+        @backtrace ||= @error
+          .backtrace
+          .reject { |line| @backtrace_silencers.any? { |silencer| line.match?(silences) } }
+          .map { |line| __filtered_line(line) }
       end
 
       def __filtered_line(line)

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -166,15 +166,17 @@ describe Message do
   end
 
   describe 'filtering backtraces' do
+    class TestOnlyException < StandardError; end
+
     def generate_error
       Invisible.raise_alarm
-    rescue => e
+    rescue TestOnlyException => e
       e
     end
 
     class Invisible
       def self.raise_alarm
-        raise 'Example failure'
+        raise TestOnlyException, 'Example failure'
       end
     end
 
@@ -190,7 +192,7 @@ describe Message do
     describe 'regex values' do
       let(:backtrace_silencers) do
         [
-          /invisible/
+          /invisible/i
         ]
       end
 
@@ -199,6 +201,22 @@ describe Message do
 
         backtrace_silencers.each do |silencer_regex|
           refute backtrace.find { |line| line.match? silencer_regex }, "Backtrace should not have a line starting '#{silencer_regex}'\n\t#{backtrace.join("\n\t")}"
+        end
+      end
+    end
+
+    describe 'string values' do
+      let(:backtrace_silencers) do
+        [
+          "Invisible"
+        ]
+      end
+
+      it 'removes lines matching the keys' do
+        backtrace = subject.error.backtrace
+
+        backtrace_silencers.each do |silencer_string|
+          refute backtrace.find { |line| line.include? silencer_string }, "Backtrace should not have a line starting '#{silencer_string}'\n\t#{backtrace.join("\n\t")}"
         end
       end
     end


### PR DESCRIPTION
Add backtrace silencers in a similar pattern to backtrace filters.

# Merge notes
PR currently includes the NDC memoisation branch which is also required in the Web project.
There is an outstanding job to reconcile the NDC memoisation and the mainline `gshutler/hatcher#master`; until then, the NDC patch is needed in Cronofy (hence this fork)

To avoid making a bigger mess, this should be merged by:
* Rebasing on master
* Merging into master
* Rebasing the `remove-ndc-memoisation` branch on the new master.
* PRing the new cronofy/hatchet master against gshutler/hatchet